### PR TITLE
Fix deprecated syntax

### DIFF
--- a/src/Quantum.jl
+++ b/src/Quantum.jl
@@ -61,12 +61,12 @@ module Quantum
 	#####################################
 	#abstract types######################
 	#####################################
-	abstract Dirac
-	abstract AbstractScalar <: Dirac
-	abstract AbstractOperator <: Dirac
-	abstract State{S} <: Dirac
+	abstract type Dirac end
+	abstract type AbstractScalar<:Dirac end
+	abstract type AbstractOperator<:Dirac end
+	abstract type State{S}<:Dirac end
 
-	typealias DiracCoeff Union(Number, AbstractScalar)
+	const = DiracCoeff Union(Number, AbstractScalar)
 
 	#####################################
 	#includes############################


### PR DESCRIPTION
Fixed deprecated typing syntax, suggested by Julia REPL when attempting "using Quantum".